### PR TITLE
ENV Var for config path + small fixes

### DIFF
--- a/fishermand/cmd/fishermand/main.go
+++ b/fishermand/cmd/fishermand/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"os"
+
 	"github.com/henrysdev/fisherman/fishermand/pkg/application"
 )
 
 func main() {
-	application.Run("/Users/henry.warren/go/src/github.com/henrysdev/fisherman/fishermand/config/config.yml")
+	configFilepath := os.Getenv("FISHERMAN_PATH")
+	application.Run(configFilepath)
 }

--- a/fishermand/config/config.yml
+++ b/fishermand/config/config.yml
@@ -1,4 +1,4 @@
 temp_dir: /tmp/fisherman/
 fifo_pipe: /tmp/fisherman/cmdpipe
 update_frequency: 0
-max_cmds_per_update: 0
+max_cmds_per_update: 1

--- a/fishermand/pkg/http_client/dispatch.go
+++ b/fishermand/pkg/http_client/dispatch.go
@@ -3,8 +3,8 @@ package http_client
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 
 	"github.com/henrysdev/fisherman/fishermand/pkg/common"
@@ -55,6 +55,6 @@ func (c *Dispatcher) SendCmdHistoryUpdate(commands []*common.ExecutionRecord) er
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(respBody))
+	log.Println(string(respBody))
 	return nil
 }

--- a/fishermand/pkg/message_apid/message_handler.go
+++ b/fishermand/pkg/message_apid/message_handler.go
@@ -2,6 +2,7 @@ package message_apid
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -36,7 +37,7 @@ func NewMessageHandler() *MessageHandler {
 func (m *MessageHandler) ProcessMessage(msgBytes []byte, buffer BufferAPI) error {
 	shellMessage, err := bytesToMessage(msgBytes)
 	if err != nil {
-		fmt.Println(common.ShellMessageFormatError(err.Error()))
+		log.Println(common.ShellMessageFormatError(err.Error()))
 		return nil
 	}
 

--- a/fishermand/pkg/utils/utils.go
+++ b/fishermand/pkg/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,7 +23,7 @@ func FileExists(filename string) bool {
 // PrettyPrintCommands prints out lists of commands formatted for convenient debugging
 func PrettyPrintCommands(commands []*common.ExecutionRecord) {
 	b, _ := json.MarshalIndent(commands, "", " ")
-	fmt.Println(string(b))
+	log.Println(string(b))
 }
 
 // RemoveFile removes the file descriptor at the provided location


### PR DESCRIPTION
- Use environment variable for specifying path to config file
- Change all fmt lines to use logger
- Change default config max commands to 1